### PR TITLE
Cabol.4.add_support_for_maps

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ follow these steps:
 
 ```erlang
 {deps, [
-  {sumo_db_riak, "0.0.1"}
+  {sumo_db_riak, "0.1.0"}
 ]}.
 ```
 

--- a/rebar.config
+++ b/rebar.config
@@ -26,7 +26,7 @@
 %% == Dependencies ==
 
 {deps, [
-  {sumo_db, "0.6.1"},
+  {sumo_db, "0.6.4"},
   {riakc, "2.4.1"},
   {iso8601, "1.1.2", {pkg, inaka_iso8601}}
 ]}.

--- a/src/sumo_db_riak.app.src
+++ b/src/sumo_db_riak.app.src
@@ -1,15 +1,21 @@
 {application, sumo_db_riak, [
-  {description, "SUMO RIAK ADAPTER."},
-  {vsn, "0.0.1"},
+  {description, "SumoDB Riak Adapter."},
+  {vsn, "0.1.0"},
   {id, "sumo_db_riak"},
   {registered, []},
   {applications, [
     kernel,
     stdlib,
-    sumo_db
+    sumo_db,
+    riakc
   ]},
   {modules, []},
   {mod, {sumo_db_riak, []}},
   {env, []},
+  {maintainers, ["Inaka"]},
+  {licenses, ["Apache 2.0"]},
+  {links, [
+    {"Github", "https://github.com/inaka/sumo_db_riak"}
+  ]},
   {build_tools, ["rebar3"]}
 ]}.

--- a/test/nested_docs_SUITE.erl
+++ b/test/nested_docs_SUITE.erl
@@ -89,7 +89,7 @@ find_by(_Config) ->
       total     := 300}
   ] = Results2,
 
-  PO1 = sumo:find(purchases, <<"ID1">>),
+  PO1 = sumo:fetch(purchases, <<"ID1">>),
   #{id        := <<"ID1">>,
     currency  := <<"USD">>,
     items     := [#{part_num := <<"123">>}, #{part_num := <<"456">>}],
@@ -98,7 +98,7 @@ find_by(_Config) ->
     bill_to   := #{city := <<"city1">>, country := <<"US">>},
     total     := 300} = PO1,
 
-  notfound = sumo:find(purchases, <<"ID123">>),
+  notfound = sumo:fetch(purchases, <<"ID123">>),
 
   Results3 = sumo:find_by(
     purchases, [{'ship_to.city', <<"city2">>}]),
@@ -119,17 +119,17 @@ find_by(_Config) ->
 
 -spec update(config()) -> ok.
 update(_Config) ->
-  PO1 = sumo:find(purchases, <<"ID1">>),
+  PO1 = sumo:fetch(purchases, <<"ID1">>),
 
   PO1x = sumo_test_purchase_order:order_num(PO1, <<"0001">>),
   sumo:persist(purchases, PO1x),
 
-  PO1x = sumo:find(purchases, <<"ID1">>),
+  PO1x = sumo:fetch(purchases, <<"ID1">>),
 
   PO1y = sumo_test_purchase_order:order_num(PO1x, <<"00011">>),
   sumo:persist(purchases, PO1y),
 
-  PO1y = sumo:find(purchases, <<"ID1">>),
+  PO1y = sumo:fetch(purchases, <<"ID1">>),
 
   ok.
 

--- a/test/test.config
+++ b/test/test.config
@@ -6,8 +6,8 @@
 
    {storage_backends, [
      {sumo_test_backend_riak, sumo_backend_riak, [
-       {host, "127.0.0.1"},
-       {port, 8087},
+       {host, "192.168.99.100"},
+       {port, 32769},
        {poolsize, 10}
      ]}
    ]},


### PR DESCRIPTION
[Fix #4] Use term_to_binary and binary_to_term to handle Erlang terms.
Upgrade sumo_db to version 0.6.4.