### PR TITLE
Drop CI testing on R16 and 17 - keep only 18 and 19

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,6 @@ language: erlang
 otp_release:
   - 19.2
   - 18.3
-  - 17.5
-  - R16B03-1
 services:
   - riak
 before_install:


### PR DESCRIPTION
Please refer to commit message for details.